### PR TITLE
Disable pagination for describe-images query

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -101,7 +101,7 @@ runs:
       if: env.EXITS_IMAGE != 'true' && inputs.DISABLE_CACHE != 'true'
       shell: bash
       run: |
-        latest_sha=$(aws ecr describe-images --repository-name ${{ inputs.AWS_ECR_REPOSITORY }} --region ${{ inputs.AWS_REGION }} --query 'sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]' --output text)
+        latest_sha=$(aws ecr describe-images --no-paginate --repository-name ${{ inputs.AWS_ECR_REPOSITORY }} --region ${{ inputs.AWS_REGION }} --query 'sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]' --output text)
         echo LATEST_TAG=$latest_sha >> $GITHUB_ENV
 
     - name: Docker build and push with cache inlined


### PR DESCRIPTION
describe-images when done with an output for text may paginate the requests and run separate queries for each call. With the current query it will return the first sorted tag for each page.

the `--no-paginate` flag disables pagination and only returns the first page

![image](https://github.com/steplix/cicd-steplix-deploy-ecr-and-cloudformation/assets/121039328/ab933cc8-eb3c-43e2-8b3b-23b516b07c0a)
